### PR TITLE
HOFF-172: Add checkbox with notBothOptions validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,18 +45,6 @@ Install the dependencies
 yarn
 ```
 
-Move into the example folder
-
-```bash
-cd example
-```
-
-Install any example app specific dependencies
-
-```bash
-yarn
-```
-
 Run in development mode
 
 ```bash

--- a/apps/demo/behaviours/country-select.js
+++ b/apps/demo/behaviours/country-select.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = superclass => class extends superclass {
   configure(req, res, next) {
     const homeOfficeCountries = [''].concat(require('homeoffice-countries').allCountries);

--- a/apps/demo/fields.js
+++ b/apps/demo/fields.js
@@ -1,8 +1,15 @@
 /* eslint-disable */
 'use strict';
 
+const _ = require('lodash');
+
 const dateComponent = require('hof').components.date;
 const staticAppealStages = require('./lib/staticAppealStages');
+
+function notBothOptions(vals) {
+  const values = _.castArray(vals);
+  return !(values.length > 1 && values.indexOf('unspecified') > -1);
+}
 
 module.exports = {
   'landing-page-radio': {
@@ -87,12 +94,34 @@ module.exports = {
     'ignore-defaults': true,
     // apply the other default formatters
     formatter: ['trim', 'hyphens'],
-    // attributes here are passed to the field element
     validate: ['required', { type: 'maxlength', arguments: 5000 }],
+    // attributes here are passed to the field element
     attributes: [{
       attribute: 'rows',
       value: 8
     }]
+  },
+  weaponsTypes:{
+    mixin: 'checkbox-group',
+    labelClassName: 'visuallyhidden',
+    validate: ['required', notBothOptions],
+    options: [
+      {
+        value: 'unspecified',
+        child: 'partials/or'
+      },        
+      'fully_automatic',
+      'self_loading',
+      'short_pistols',
+      'short_self_loading',
+      'large_revolvers',
+      'rocket_launchers',
+      'air_rifles',
+      'fire_noxious_substance',
+      'disguised_firearms',
+      'military_use_rockets',
+      'projecting_launchers'
+    ]
   },
   appealStages: {
     mixin: 'select',

--- a/apps/demo/index.js
+++ b/apps/demo/index.js
@@ -66,6 +66,11 @@ module.exports = {
     },
     '/text-input-area': {
       fields: ['complaintDetails'],
+      next: '/checkbox-not-both-options'
+    },
+    '/checkbox-not-both-options':{
+      template: 'weapons',
+      fields: ['weaponsTypes'],
       next: '/select'
     },
     '/select':{

--- a/apps/demo/sections/summary-data-sections.js
+++ b/apps/demo/sections/summary-data-sections.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const moment = require('moment');
 const PRETTY_DATE_FORMAT = 'Do MMMM YYYY';
 const APPEAL_STAGES = require('../lib/staticAppealStages').getstaticAppealStages();

--- a/apps/demo/sections/summary-data-sections.js
+++ b/apps/demo/sections/summary-data-sections.js
@@ -36,5 +36,8 @@ module.exports = {
   ],
   complaintDetails: [
     'complaintDetails'
+  ],
+  weaponsTypes: [
+    'weaponsTypes'
   ]
 };

--- a/apps/demo/translations/src/en/fields.json
+++ b/apps/demo/translations/src/en/fields.json
@@ -87,6 +87,48 @@
     "label": "Select a country",
     "hint": "Start to type the country name and options will appear"
   },
+  "weaponsTypes":{
+    "label": "Selected weapon types(s)",
+    "legend": "Select all that apply",
+    "options": {
+      "unspecified": {
+        "label": "Unspecified sections and quantities"
+      },
+      "fully_automatic": {
+        "label": "Fully automatic or burst-fire weapons - Section 5(1)(a)"
+      },
+      "self_loading": {
+        "label": "Self-loading or pump-action rifles and carbines but not pistols - Section 5(1)(ab)"
+      },
+      "short_pistols": {
+        "label": "Short firearms pistols and revolvers - Section 5(1)(aba)"
+      },
+      "short_self_loading": {
+        "label": "Short self-loading or pump-action shotguns - Section 5(1)(ac)"
+      },
+      "large_revolvers": {
+        "label": "Large smooth-bore revolvers - Section 5(1)(ad)"
+      },
+      "rocket_launchers": {
+        "label": "Rocket launchers and mortars - Section 5(1)(ae)"
+      },
+      "air_rifles": {
+        "label": "Air rifle, air gun or air pistol for use with self-contained gas cartridge - Section 5(1)(af)"
+      },
+      "fire_noxious_substance": {
+        "label": "Weapons which fire noxious substances - Section 5(1)(b)"
+      },
+      "disguised_firearms": {
+        "label": "Firearms disguised as other objects - Section 5(1A)(a)"
+      },
+      "military_use_rockets": {
+        "label": "Rockets/ammunition with exploding missiles for military use - Section 5(1A)(b)"
+      },
+      "projecting_launchers": {
+        "label": "Launchers or projecting apparatus for use with the rockets or ammunition detailed above - Section 5(1A)(c)"
+      }
+    }
+  },
   "appealStages": {
     "label": "Appeal stage",
     "options": {

--- a/apps/demo/translations/src/en/pages.json
+++ b/apps/demo/translations/src/en/pages.json
@@ -36,6 +36,11 @@
     "header": "What are the details of your complaint?",
     "intro": "Briefly summarise your complaint. Include anything that can help our investigation."
   },
+  "checkbox-not-both-options":{
+    "header": "Which sections do the weapons or components fall under?",
+    "intro": "Select all that apply and state the maximum quantities held at any one time. If the sections and quantities aren't backed up by the evidence provided, it may delay the application or result in the authority not being approved.",
+    "important": "Only in certain circumstances, such as transporting prohibited items under seal, should you select the unspecified option."
+  },
   "select":{
     "header": "What is the appeal stage?",
     "intro": "Choose an appeal stage from the drop down menu"
@@ -63,6 +68,9 @@
       },
       "complaintDetails": {
         "header": "Complaint details"
+      }, 
+      "weaponsTypes": {
+        "header": "Weapons details"
       }
     }
   },

--- a/apps/demo/translations/src/en/validation.json
+++ b/apps/demo/translations/src/en/validation.json
@@ -45,6 +45,10 @@
     "default": "Enter details about why you are making a complaint",
     "maxlength": "Keep to the 5000 character limit"
   },
+  "weaponsTypes":{
+    "required": "Select at least one option",
+    "notBothOptions": "You can't choose unspecified categories and choose a category. You must deselect the unspecified category option, or the selected categories to continue"
+  },
   "appealStages": {
     "required": "Select an appeal stage from the list"
   }

--- a/apps/demo/views/partials/or.html
+++ b/apps/demo/views/partials/or.html
@@ -1,0 +1,3 @@
+<div class="form-block">
+  or
+</div> 

--- a/apps/demo/views/weapons.html
+++ b/apps/demo/views/weapons.html
@@ -1,0 +1,14 @@
+{{<partials-page}}
+   {{$page-content}}
+
+     <div class="panel-indent">
+       <p>{{#t}}pages.checkbox-not-both-options.important{{/t}}</p>
+     </div>
+
+     {{#fields}}
+       {{#renderField}}{{/renderField}}
+     {{/fields}}
+
+     {{#input-submit}}continue{{/input-submit}}
+   {{/page-content}}
+ {{/partials-page}} 

--- a/test/_features/example_app/complex_form.feature
+++ b/test/_features/example_app/complex_form.feature
@@ -32,6 +32,10 @@ Feature: Complex Form
     Then I should be on the 'text-input-area' page showing 'What are the details of your complaint?'
     Then I fill 'complaintDetails' text area with 'I would like to make a complaint'
     Then I click the 'Continue' button
+    Then I should be on the 'checkbox-not-both-options' page showing 'Which sections do the weapons or components fall under?'
+    Then I check 'weaponsTypes-fully_automatic'
+    Then I check 'weaponsTypes-large_revolvers'
+    Then I click the 'Continue' button
     Then I should be on the 'select' page showing 'What is the appeal stage?'
     Then I select 'appealStages' and '01. First Tier IAC Appeal - In Country Appeals'
     Then I click the 'Continue' button

--- a/test/_features/example_app/validation.feature
+++ b/test/_features/example_app/validation.feature
@@ -115,6 +115,15 @@ Feature: validations
     Then I should see the 'Enter details about why you are making a complaint' error
     Then I fill 'complaintDetails' text area with 'I would like to make a complaint'
     Then I click the 'Continue' button
+    Then I continue to the next step
+    Then I should see the 'Select at least one option' error
+    Then I check 'weaponsTypes-unspecified'
+    Then I check 'weaponsTypes-fully_automatic'
+    Then I continue to the next step
+    Then I should see the 'You can\'t choose unspecified categories and choose a category. You must deselect the unspecified category option, or the selected categories to continue' error
+    Then I uncheck 'weaponsTypes-unspecified'
+    Then I check 'weaponsTypes-projecting_launchers'
+    Then I continue to the next step
     Then I click the 'Continue' button
     Then I should see the 'Select an appeal stage from the list' error
     Then I select 'appealStages' and '01. First Tier IAC Appeal - In Country Appeals'

--- a/test/_features/step_definitions/steps.js
+++ b/test/_features/step_definitions/steps.js
@@ -19,6 +19,10 @@ Then('I check {string}', async function (name) {
   await this.page.check(`#${name}`);
 }.bind(World));
 
+Then('I uncheck {string}', async function (name) {
+  await this.page.uncheck(`#${name}`);
+}.bind(World));
+
 Then('I choose {string}', async function (name) {
   await this.page.click(`text=${name}`);
 }.bind(World));


### PR DESCRIPTION
What? 

Add a step with checkboxes and the notBothOptions validation, used in one step of the firearms form. Also edited the Readme and added 'use strict' to some files missing this. 

Why?

Demo the feature in the complex form.

Testing? 
Done on a branch in the hof repo, and was passing tests there. 
