### PR TITLE
HOFF-239: Update text on landing page

### DIFF
--- a/apps/demo/translations/src/en/fields.json
+++ b/apps/demo/translations/src/en/fields.json
@@ -1,18 +1,17 @@
 {
   "landing-page-radio": {
-    "legend": "Which form would you like to explore?",
     "options": {
       "basic-form": {
         "label": "Basic form",
-        "hint": "An example of a simple form produced using the hof framework. This form demos common components used by services using the hof framework."
+        "hint": "An example of a simple form produced using the HOF framework. This form showcases components and features available in the HOF framework."
       },
       "complex-form": {
         "label": "Complex form",
-        "hint": "An example of a form produced using the hof framework. This longer demo includes some steps from the basic form and features less common components used in other services using hof."
+        "hint": "An example of a form produced using the HOF framework. This form showcases more advanced features available in the HOF framework."
       },
       "build-your-own-form": {
         "label": "Build your own form",
-        "hint": "Link to the HOF documentation, with instructions on how to build your own hof form."
+        "hint": "Link to the HOF documentation, with instructions on how to build your own HOF form."
       }
     }
   },

--- a/apps/demo/translations/src/en/fields.json
+++ b/apps/demo/translations/src/en/fields.json
@@ -3,13 +3,16 @@
     "legend": "Which form would you like to explore?",
     "options": {
       "basic-form": {
-        "label": "Basic form"
+        "label": "Basic form",
+        "hint": "An example of a simple form produced using the hof framework. This form demos common components used by services using the hof framework."
       },
       "complex-form": {
-        "label": "Complex form"
+        "label": "Complex form",
+        "hint": "An example of a form produced using the hof framework. This longer demo includes some steps from the basic form and features less common components used in other services using hof."
       },
       "build-your-own-form": {
-        "label": "Build your own form"
+        "label": "Build your own form",
+        "hint": "Link to the HOF documentation, with instructions on how to build your own hof form."
       }
     }
   },

--- a/apps/demo/translations/src/en/journey.json
+++ b/apps/demo/translations/src/en/journey.json
@@ -1,3 +1,3 @@
 {
-  "header": "HOF Bootstrap Example Form"
+  "header": "Home Office Forms (HOF) Demo"
 }

--- a/apps/demo/translations/src/en/pages.json
+++ b/apps/demo/translations/src/en/pages.json
@@ -70,6 +70,6 @@
     "title": "Application complete",
     "alert": "Application complete", 
     "subheader": "Thank you",
-    "content": "You have completed an example of a hof form."
+    "content": "You have completed an example of a form built using hof."
   }
 }

--- a/apps/demo/translations/src/en/pages.json
+++ b/apps/demo/translations/src/en/pages.json
@@ -67,9 +67,9 @@
     }
   },
   "confirmation": {
-    "title": "Application sent",
-    "alert": "Application sent", 
-    "subheader": "What happens next",
-    "content": "We’ll contact you with the decision of your application or if we need more information from you."
+    "title": "Application complete",
+    "alert": "Application complete", 
+    "subheader": "Thank you",
+    "content": "You have completed an example of a hof form."
   }
 }

--- a/test/_features/example_app/basic_form.feature
+++ b/test/_features/example_app/basic_form.feature
@@ -33,6 +33,6 @@ Feature: Basic Form
     Then I click the 'Continue' button
     Then I should be on the 'confirm' page showing 'Check your answers before submitting your application.'
     Then I continue to the next step
-    Then I should see 'Application sent' on the page
+    Then I should see 'Application complete' on the page
     Then I click the 'Start again' button
     Then I should be on the 'landing-page' page showing 'Choose one of the options below and press continue.'

--- a/test/_features/example_app/complex_form.feature
+++ b/test/_features/example_app/complex_form.feature
@@ -37,6 +37,6 @@ Feature: Complex Form
     Then I click the 'Continue' button
     Then I should be on the 'confirm' page showing 'Check your answers before submitting your application.'
     Then I continue to the next step
-    Then I should see 'Application sent' on the page
+    Then I should see 'Application complete' on the page
     Then I click the 'Start again' button
     Then I should be on the 'landing-page' page showing 'Choose one of the options below and press continue.'

--- a/test/_features/example_app/validation.feature
+++ b/test/_features/example_app/validation.feature
@@ -59,7 +59,7 @@ Feature: validations
     Then I click the 'Continue' button
     Then I should be on the 'confirm' page showing 'Check your answers before submitting your application.'
     Then I continue to the next step
-    Then I should see 'Application sent' on the page
+    Then I should see 'Application complete' on the page
     Then I click the 'Start again' button
     Then I should be on the 'landing-page' page showing 'Choose one of the options below and press continue.'
   @complex_form
@@ -120,6 +120,6 @@ Feature: validations
     Then I select 'appealStages' and '01. First Tier IAC Appeal - In Country Appeals'
     Then I click the 'Continue' button
     Then I continue to the next step
-    Then I should see 'Application sent' on the page
+    Then I should see 'Application complete' on the page
     Then I click the 'Start again' button
     Then I should be on the 'landing-page' page showing 'Choose one of the options below and press continue.'


### PR DESCRIPTION
What? 

Update text on the landing page, confirmation and the black banner. 

Why?  

Update text on the landing page - to give the forms more context. Text was also updated on the confirmation page on the banner to be more suitable for the demo. 