### PR TITLE
Hoff 213 continue saved form step

### DIFF
--- a/apps/demo/fields.js
+++ b/apps/demo/fields.js
@@ -20,6 +20,27 @@ module.exports = {
     },
     options: ['basic-form', 'complex-form', 'build-your-own-form']
   },
+  continueSavedForms: {
+    mixin: 'radio-group',
+    validate: 'required',
+    legend: {
+      className: 'visuallyhidden'
+    },
+    options: [{
+      value: 'yes',
+      toggle: 'savedFormEmail',
+      child: 'partials/saved-form-email'
+    }, {
+      value: 'no'
+    }]
+  },
+  savedFormEmail: {
+    validate: ['email', 'required'],
+    dependent: {
+      field: 'continueSavedForms',
+      value: 'yes'
+    }
+  },
   name: {
     validate: ['required', 'notUrl', { type: 'maxlength', arguments: 200 }],
   },

--- a/apps/demo/index.js
+++ b/apps/demo/index.js
@@ -13,16 +13,43 @@ module.exports = {
         'landing-page-radio'
       ],
       next: '/name',
-      forks: [{
-        target: '/build-your-own-form',
-        condition: {
-          field: 'landing-page-radio',
-          value: 'build-your-own-form'
+      forks: [
+        {
+          target: '/build-your-own-form',
+          condition: {
+            field: 'landing-page-radio',
+            value: 'build-your-own-form'
+          }
+        },
+        {
+          target: '/continue-saved-form',
+          condition: {
+            field: 'landing-page-radio',
+            value: 'complex-form'
+          }
         }
-      }],
+      ],
     },
     '/build-your-own-form': {
       template: 'form-guidance-link'
+    },
+    '/continue-saved-form': {
+      template: 'continue-saved-form',
+      fields: [
+        'continueSavedForms', 
+        'savedFormEmail'
+      ],
+      next: '/forms',
+      forks: [{
+        target: '/name',
+        condition: {
+          field: 'continueSavedForms',
+          value: 'no'
+        }
+      }]
+    },
+    '/forms':{
+
     },
     '/name': {
       fields: ['name'],

--- a/apps/demo/translations/src/en/fields.json
+++ b/apps/demo/translations/src/en/fields.json
@@ -15,6 +15,20 @@
       }
     }
   },
+  "continueSavedForms": {
+    "options":{
+      "yes": {
+        "label": "Yes"
+      },
+      "no": {
+        "label": "No"
+      }
+    }
+  },
+  "savedFormEmail": {
+    "label": "Enter the email address you used to save the form",
+    "hint": "Email address"
+  },
   "name": {
     "label": "Full name"
   },

--- a/apps/demo/translations/src/en/pages.json
+++ b/apps/demo/translations/src/en/pages.json
@@ -7,6 +7,9 @@
     "title": "Build your own form",
     "subheader": "Access the build your own form guidance link"
   },
+  "continue-saved-form": {
+    "header": "Do you want to continue a saved form?"
+  },
   "name": {
     "header": "What is your full name?"
   },

--- a/apps/demo/translations/src/en/validation.json
+++ b/apps/demo/translations/src/en/validation.json
@@ -2,6 +2,12 @@
   "landing-page-radio": {
     "required": "Select an option below and press continue"
   },
+  "continueSavedForms": {
+    "required": "Do you want to continue a form you have previously saved?"
+  },
+  "savedFormEmail": { 
+    "default": "Enter the email address you used to save the form in the correct format"
+  },
   "name":{
     "default": "Enter your full name"
   },

--- a/apps/demo/translations/src/en/validation.json
+++ b/apps/demo/translations/src/en/validation.json
@@ -6,7 +6,8 @@
     "required": "Do you want to continue a form you have previously saved?"
   },
   "savedFormEmail": { 
-    "default": "Enter the email address you used to save the form in the correct format"
+    "required": "Enter the email address you used to save the form",
+    "email": "Enter the email address you used to save the form in the correct format"
   },
   "name":{
     "default": "Enter your full name"

--- a/apps/demo/views/continue-saved-form.html
+++ b/apps/demo/views/continue-saved-form.html
@@ -1,0 +1,8 @@
+{{<partials-page}}
+   {{$page-content}}
+
+     {{#renderField}}continueSavedForms{{/renderField}}
+
+     {{#input-submit}}continue{{/input-submit}}
+   {{/page-content}}
+ {{/partials-page}} 

--- a/apps/demo/views/partials/saved-form-email.html
+++ b/apps/demo/views/partials/saved-form-email.html
@@ -1,0 +1,5 @@
+<div id="{{toggle}}-panel" class="reveal" aria-hidden="false">
+  <div class="panel-indent">
+    {{#input-text}}{{toggle}}{{/input-text}}
+  </div>
+</div> 

--- a/test/_features/example_app/complex_form.feature
+++ b/test/_features/example_app/complex_form.feature
@@ -2,10 +2,13 @@
 Feature: Complex Form
   A user should select complex form on the landing page
 
-  Scenario: Complex Form Submission
+  Scenario: Complex Form Submission Without Continuing A Saved Form
     Given I start the 'base' application journey
     Then I should be on the 'landing-page' page showing 'Choose one of the options below and press continue.'
     Then I choose 'Complex form'
+    Then I continue to the next step
+    Then I should be on the 'continue-saved-form' page showing 'Do you want to continue a saved form?'
+    Then I choose 'No'
     Then I continue to the next step
     Then I should be on the 'name' page showing 'What is your full name?'
     Then I fill 'name' with 'Jane Doe'
@@ -44,3 +47,14 @@ Feature: Complex Form
     Then I should see 'Application complete' on the page
     Then I click the 'Start again' button
     Then I should be on the 'landing-page' page showing 'Choose one of the options below and press continue.'
+
+  @continue-saved-form 
+  Scenario: Complex Form Submission Continuing A Saved Form
+    Given I start the 'base' application journey
+    Then I should be on the 'landing-page' page showing 'Choose one of the options below and press continue.'
+    Then I choose 'Complex form'
+    Then I continue to the next step
+    Then I should be on the 'continue-saved-form' page showing 'Do you want to continue a saved form?'
+    Then I choose 'Yes'
+    Then I fill 'savedFormEmail' with 'email@test.com'
+    Then I continue to the next step

--- a/test/_features/example_app/validation.feature
+++ b/test/_features/example_app/validation.feature
@@ -63,11 +63,14 @@ Feature: validations
     Then I click the 'Start again' button
     Then I should be on the 'landing-page' page showing 'Choose one of the options below and press continue.'
   @complex_form
-  Scenario: Full Complex Form Submission
+  Scenario: Full Complex Form Submission Without Continuing A Saved Form
     Given I start the 'base' application journey
     Then I continue to the next step
     Then I should see the 'Select an option below and press continue' error
     Then I choose 'Complex form'
+    Then I continue to the next step
+    Then I should see the 'Do you want to continue a form you have previously saved?' error
+    Then I choose 'No'
     Then I continue to the next step
     Then I click the 'Continue' button
     Then I should see the 'Enter your full name' error
@@ -132,3 +135,16 @@ Feature: validations
     Then I should see 'Application complete' on the page
     Then I click the 'Start again' button
     Then I should be on the 'landing-page' page showing 'Choose one of the options below and press continue.'
+
+  @complex_form @continue-saved-form
+  Scenario: Partial Complex Form Submission Continuing A Saved Form
+    Given I start the 'base' application journey
+    Then I continue to the next step
+    Then I should see the 'Select an option below and press continue' error
+    Then I choose 'Complex form'
+    Then I continue to the next step
+    Then I continue to the next step
+    Then I should see the 'Do you want to continue a form you have previously saved?' error
+    Then I choose 'Yes'
+    Then I continue to the next step
+    Then I should see the 'Enter the email address used to save the form in the correct format' error

--- a/test/_features/example_app/validation.feature
+++ b/test/_features/example_app/validation.feature
@@ -69,6 +69,7 @@ Feature: validations
     Then I should see the 'Select an option below and press continue' error
     Then I choose 'Complex form'
     Then I continue to the next step
+    Then I continue to the next step
     Then I should see the 'Do you want to continue a form you have previously saved?' error
     Then I choose 'No'
     Then I continue to the next step
@@ -147,4 +148,9 @@ Feature: validations
     Then I should see the 'Do you want to continue a form you have previously saved?' error
     Then I choose 'Yes'
     Then I continue to the next step
-    Then I should see the 'Enter the email address used to save the form in the correct format' error
+    Then I should see the 'Enter the email address you used to save the form' error
+    Then I fill 'savedFormEmail' with 'Fake email'
+    Then I continue to the next step
+    Then I should see the 'Enter the email address you used to save the form in the correct format' error
+    Then I fill 'savedFormEmail' with 'email@test.com'
+    Then I continue to the next step


### PR DESCRIPTION
What?

Add continue-saved-form step to the complex form demo, as part of incorporating a demo to the example app. The page asks the user if they want to continue a form they saved previously.

Why

Enable the user to eventually go back to a saved form saved under that email address.