### PR TITLE
HOFF-212 add save form step

### DIFF
--- a/apps/demo/fields.js
+++ b/apps/demo/fields.js
@@ -152,5 +152,34 @@ module.exports = {
       value: '',
       label: 'fields.appealStages.options.null'
     }].concat(staticAppealStages.getstaticAppealStages())
+  },
+  saveForm: {
+    mixin: 'radio-group',
+    validate: ['required'],
+    legend: {
+      className: 'visuallyhidden'
+    },
+    options: [
+      {
+        value: 'yes',
+        toggle: ['saveEmail'],
+        child: 'partials/save-email-ref',
+      },
+      'no'
+    ]
+  },
+  saveEmail: {
+    validate: ['required', 'email'],
+    dependent: {
+      value: 'yes',
+      field: 'saveForm'
+    }
+  },
+  saveRef: {
+    validate: ['required'],
+    dependent: {
+      value: 'yes',
+      field: 'saveForm'
+    }
   }
 }

--- a/apps/demo/index.js
+++ b/apps/demo/index.js
@@ -102,6 +102,18 @@ module.exports = {
     },
     '/select':{
       fields: ['appealStages'],
+      next: '/save-form'
+    },
+    '/save-form': {
+      fields: ['saveForm', 'saveEmail', 'saveRef'],
+      forks: [{
+        target: '/save-confirmation',
+        condition: {
+          field: ['saveForm'],
+          value: 'yes'
+        }
+      }
+      ],
       next: '/confirm'
     },
     '/confirm': {

--- a/apps/demo/index.js
+++ b/apps/demo/index.js
@@ -116,6 +116,8 @@ module.exports = {
       ],
       next: '/confirm'
     },
+    '/save-confirmation': {
+    },
     '/confirm': {
       behaviours: [SummaryPageBehaviour, 'complete'],
       sections: require('./sections/summary-data-sections'),

--- a/apps/demo/translations/src/en/fields.json
+++ b/apps/demo/translations/src/en/fields.json
@@ -148,5 +148,22 @@
     "options": {
       "null": "Select..."
     }
+  },
+  "saveForm": {
+    "options": {
+      "yes": {
+        "label": "Yes"
+      },
+      "no": {
+        "label": "No"
+      }
+    }
+  },
+  "saveEmail": {
+    "label": "Enter your email address"
+  },
+  "saveRef": {
+    "label": "Create a memorable reference for your form",
+    "hint": "Ensure your reference is something that is easy to remember, for example your name"
   }
 }

--- a/apps/demo/translations/src/en/fields.json
+++ b/apps/demo/translations/src/en/fields.json
@@ -163,7 +163,7 @@
     "label": "Enter your email address"
   },
   "saveRef": {
-    "label": "Create a memorable reference for your form",
-    "hint": "Ensure your reference is something that is easy to remember, for example your name"
+    "label": "What is your reference for this form?",
+    "hint": "This is for you to keep track of your saved forms"
   }
 }

--- a/apps/demo/translations/src/en/pages.json
+++ b/apps/demo/translations/src/en/pages.json
@@ -48,6 +48,9 @@
     "header": "What is the appeal stage?",
     "intro": "Choose an appeal stage from the drop down menu"
   },
+  "save-form": {
+    "header": "Would you like to save your form?"
+  },
   "confirm": {
     "header": "Check your answers before submitting your application.",
     "sections": {

--- a/apps/demo/translations/src/en/validation.json
+++ b/apps/demo/translations/src/en/validation.json
@@ -60,12 +60,12 @@
     "required": "Select an appeal stage from the list"
   },
   "saveForm": {
-    "required": "Select an option below"
+    "required": "Select if you want to save your form or not"
   },
   "saveEmail": {
     "required": "Enter your email address"
   },
   "saveRef": {
-    "required": "Create a memorable reference"
+    "required": "You must enter a reference"
   }
 }

--- a/apps/demo/translations/src/en/validation.json
+++ b/apps/demo/translations/src/en/validation.json
@@ -58,5 +58,14 @@
   },
   "appealStages": {
     "required": "Select an appeal stage from the list"
+  },
+  "saveForm": {
+    "required": "Select an option below"
+  },
+  "saveEmail": {
+    "required": "Enter your email address"
+  },
+  "saveRef": {
+    "required": "Create a memorable reference"
   }
 }

--- a/apps/demo/views/partials/save-email-ref.html
+++ b/apps/demo/views/partials/save-email-ref.html
@@ -1,0 +1,8 @@
+<div id="{{toggle}}-panel" class="reveal" aria-hidden="false">
+  <div class="panel-indent">
+
+    {{#renderField}}saveEmail{{/renderField}}
+    {{#renderField}}saveRef{{/renderField}}
+    
+  </div>
+</div> 

--- a/apps/demo/views/save-form.html
+++ b/apps/demo/views/save-form.html
@@ -1,0 +1,8 @@
+{{<partials-page}}
+  {{$page-content}}
+
+    {{#renderField}}saveForm{{/renderField}}
+
+    {{#input-submit}}continue{{/input-submit}}
+  {{/page-content}}
+{{/partials-page}} 

--- a/test/_features/example_app/complex_form.feature
+++ b/test/_features/example_app/complex_form.feature
@@ -2,7 +2,7 @@
 Feature: Complex Form
   A user should select complex form on the landing page
 
-  Scenario: Complex Form Submission Without Continuing A Saved Form
+  Scenario: Complex Form Submission Without Continuing A Saved Form And Without Saving The Form
     Given I start the 'base' application journey
     Then I should be on the 'landing-page' page showing 'Choose one of the options below and press continue.'
     Then I choose 'Complex form'
@@ -42,6 +42,9 @@ Feature: Complex Form
     Then I should be on the 'select' page showing 'What is the appeal stage?'
     Then I select 'appealStages' and '01. First Tier IAC Appeal - In Country Appeals'
     Then I click the 'Continue' button
+    Then I should be on the 'save-form' page showing 'Would you like to save your form?'
+    Then I select 'No'
+    Then I click the 'Continue' button
     Then I should be on the 'confirm' page showing 'Check your answers before submitting your application.'
     Then I continue to the next step
     Then I should see 'Application complete' on the page
@@ -58,3 +61,48 @@ Feature: Complex Form
     Then I choose 'Yes'
     Then I fill 'savedFormEmail' with 'email@test.com'
     Then I continue to the next step
+
+  @save-form
+  Scenario: Complex Form Submission Saving A Form
+    Given I start the 'base' application journey
+    Then I should be on the 'landing-page' page showing 'Choose one of the options below and press continue.'
+    Then I choose 'Complex form'
+    Then I continue to the next step
+    Then I should be on the 'continue-saved-form' page showing 'Do you want to continue a saved form?'
+    Then I choose 'No'
+    Then I should be on the 'name' page showing 'What is your full name?'
+    Then I fill 'name' with 'Jane Doe'
+    Then I click the 'Continue' button
+    Then I should be on the 'dob' page showing 'What is your date of birth?'
+    Then I enter a date of birth for a 30 year old
+    Then I click the 'Continue' button
+    Then I should be on the 'address' page showing 'What is your address in the UK?'
+    Then I fill 'building' with '10 Downing Street'
+    Then I fill 'townOrCity' with 'London'
+    Then I fill 'postcode' with 'W12 3DE'
+    Then I click the 'Continue' button
+    Then I should be on the 'checkboxes' page showing 'Where does your money come from each month?'
+    Then I select 'Salary' 
+    Then I select 'Child Benefit' 
+    Then I click the 'Continue' button
+    Then I should be on the 'radio' page showing 'What country was the appeal lodged?'
+    Then I select 'England and Wales'
+    Then I click the 'Continue' button
+    Then I should be on the 'country-select' page showing 'What country is your address located?'
+    Then I fill 'countrySelect' with 'United'
+    Then I select 'United Kingdom'
+    Then I click the 'Continue' button
+    Then I should be on the 'text-input-area' page showing 'What are the details of your complaint?'
+    Then I fill 'complaintDetails' text area with 'I would like to make a complaint'
+    Then I click the 'Continue' button
+    Then I should be on the 'select' page showing 'What is the appeal stage?'
+    Then I select 'appealStages' and '01. First Tier IAC Appeal - In Country Appeals'
+    Then I click the 'Continue' button
+    Then I should be on the 'save-form' page showing 'Would you like to save your form?'
+    Then I select 'Yes'
+    Then I fill 'saveEmail' with 'test@email.com'
+    Then I fill 'saveRef' with 'My saved form'
+    Then I click the 'Continue' button
+    Then I should be on the 'save-confirmation' page showing 'Page not found'
+    Then I click the 'Start again' button
+    Then I should be on the 'landing-page' page showing 'Choose one of the options below and press continue.'

--- a/test/_features/example_app/complex_form.feature
+++ b/test/_features/example_app/complex_form.feature
@@ -62,7 +62,7 @@ Feature: Complex Form
     Then I fill 'savedFormEmail' with 'email@test.com'
     Then I continue to the next step
 
-  @save-form
+  @save_form
   Scenario: Complex Form Submission Saving A Form
     Given I start the 'base' application journey
     Then I should be on the 'landing-page' page showing 'Choose one of the options below and press continue.'
@@ -70,6 +70,7 @@ Feature: Complex Form
     Then I continue to the next step
     Then I should be on the 'continue-saved-form' page showing 'Do you want to continue a saved form?'
     Then I choose 'No'
+    Then I continue to the next step
     Then I should be on the 'name' page showing 'What is your full name?'
     Then I fill 'name' with 'Jane Doe'
     Then I click the 'Continue' button
@@ -88,12 +89,16 @@ Feature: Complex Form
     Then I should be on the 'radio' page showing 'What country was the appeal lodged?'
     Then I select 'England and Wales'
     Then I click the 'Continue' button
-    Then I should be on the 'country-select' page showing 'What country is your address located?'
+    Then I should be on the 'country' page showing 'What country is your address located?'
     Then I fill 'countrySelect' with 'United'
     Then I select 'United Kingdom'
     Then I click the 'Continue' button
     Then I should be on the 'text-input-area' page showing 'What are the details of your complaint?'
     Then I fill 'complaintDetails' text area with 'I would like to make a complaint'
+    Then I click the 'Continue' button
+    Then I should be on the 'checkbox-not-both-options' page showing 'Which sections do the weapons or components fall under?'
+    Then I check 'weaponsTypes-fully_automatic'
+    Then I check 'weaponsTypes-large_revolvers'
     Then I click the 'Continue' button
     Then I should be on the 'select' page showing 'What is the appeal stage?'
     Then I select 'appealStages' and '01. First Tier IAC Appeal - In Country Appeals'
@@ -103,6 +108,4 @@ Feature: Complex Form
     Then I fill 'saveEmail' with 'test@email.com'
     Then I fill 'saveRef' with 'My saved form'
     Then I click the 'Continue' button
-    Then I should be on the 'save-confirmation' page showing 'Page not found'
-    Then I click the 'Start again' button
-    Then I should be on the 'landing-page' page showing 'Choose one of the options below and press continue.'
+

--- a/test/_features/example_app/validation.feature
+++ b/test/_features/example_app/validation.feature
@@ -150,6 +150,8 @@ Feature: validations
     Given I start the 'base' application journey
     Then I choose 'Complex form'
     Then I continue to the next step
+    Then I continue to the next step
+    Then I should see the 'Do you want to continue a form you have previously saved?' error
     Then I choose 'Yes'
     Then I continue to the next step
     Then I should see the 'Enter the email address you used to save the form' error

--- a/test/_features/example_app/validation.feature
+++ b/test/_features/example_app/validation.feature
@@ -133,25 +133,23 @@ Feature: validations
     Then I should see the 'Select an appeal stage from the list' error
     Then I select 'appealStages' and '01. First Tier IAC Appeal - In Country Appeals'
     Then I click the 'Continue' button
+    Then I should be on the 'save-form' page showing 'Would you like to save your form?'
+    Then I continue to the next step
+    Then I should see the 'Select if you want to save your form or not' error
+    Then I should be on the 'save-form' page showing 'Would you like to save your form'
+    Then I check 'saveForm-no'
+    Then I click the 'Continue' button
+    Then I should be on the 'confirm' page showing 'Check your answers before submitting your application.'
     Then I continue to the next step
     Then I should see 'Application complete' on the page
     Then I click the 'Start again' button
     Then I should be on the 'landing-page' page showing 'Choose one of the options below and press continue.'
 
-  @complex_form @continue-saved-form
+  @complex_form @continue_saved_form
   Scenario: Partial Complex Form Submission Continuing A Saved Form
-    Then I click the 'Continue' button
-    Then I should see the 'Select an option below' error
-    Then I select 'No'
-    Then I click the 'Continue' button
-    Then I click the 'Confirm submission' button
-    Then I should see 'Application sent' on the page
-    Then I click the 'Start again' button
-    Then I should be on the 'landing-page' page showing 'Choose one of the options below and press continue.'
+    Given I start the 'base' application journey
     Then I choose 'Complex form'
     Then I continue to the next step
-    Then I continue to the next step
-    Then I should see the 'Do you want to continue a form you have previously saved?' error
     Then I choose 'Yes'
     Then I continue to the next step
     Then I should see the 'Enter the email address you used to save the form' error
@@ -161,7 +159,7 @@ Feature: validations
     Then I fill 'savedFormEmail' with 'email@test.com'
     Then I continue to the next step
 
-    @complex_form @save_form
+  @complex_form @save_form
   Scenario: Full Complex Form Submission With Saving The Form
     Given I start the 'base' application journey
     Then I choose 'Complex form'
@@ -186,21 +184,23 @@ Feature: validations
     Then I click the 'Continue' button
     Then I fill 'complaintDetails' text area with 'I would like to make a complaint'
     Then I click the 'Continue' button
+    Then I should be on the 'checkbox-not-both-options' page showing 'Which sections do the weapons or components fall under?'
+    Then I check 'weaponsTypes-fully_automatic'
+    Then I check 'weaponsTypes-large_revolvers'
+    Then I click the 'Continue' button
     Then I select 'appealStages' and '01. First Tier IAC Appeal - In Country Appeals'
     Then I click the 'Continue' button
     Then I select 'Yes'
     Then I click the 'Continue' button
     Then I should see the 'Enter your email address' error
-    Then I should see the 'Create a memorable reference' error
+    Then I should see the 'You must enter a reference' error
     Then I fill 'saveEmail' with '=testemail.com'
     Then I click the 'Continue' button
     Then I should see the 'Enter your email address in the correct format' error
-    Then I should see the 'Create a memorable reference' error
+    Then I should see the 'You must enter a reference' error
     Then I fill 'saveEmail' with 'test@email.com'
     Then I click the 'Continue' button
-    Then I should see the 'Create a memorable reference' error
+    Then I should see the 'You must enter a reference' error
     Then I fill 'saveRef' with 'My saved form'
     Then I click the 'Continue' button
-    Then I should be on the 'save-confirmation' page showing 'Page not found'
-    Then I click the 'Start again' button
-    Then I should be on the 'landing-page' page showing 'Choose one of the options below and press continue.'
+    

--- a/test/_features/example_app/validation.feature
+++ b/test/_features/example_app/validation.feature
@@ -62,8 +62,9 @@ Feature: validations
     Then I should see 'Application complete' on the page
     Then I click the 'Start again' button
     Then I should be on the 'landing-page' page showing 'Choose one of the options below and press continue.'
+    
   @complex_form
-  Scenario: Full Complex Form Submission Without Continuing A Saved Form
+  Scenario: Full Complex Form Submission Without Continuing A Saved Form And Without Saving The Form
     Given I start the 'base' application journey
     Then I continue to the next step
     Then I should see the 'Select an option below and press continue' error
@@ -139,9 +140,14 @@ Feature: validations
 
   @complex_form @continue-saved-form
   Scenario: Partial Complex Form Submission Continuing A Saved Form
-    Given I start the 'base' application journey
-    Then I continue to the next step
-    Then I should see the 'Select an option below and press continue' error
+    Then I click the 'Continue' button
+    Then I should see the 'Select an option below' error
+    Then I select 'No'
+    Then I click the 'Continue' button
+    Then I click the 'Confirm submission' button
+    Then I should see 'Application sent' on the page
+    Then I click the 'Start again' button
+    Then I should be on the 'landing-page' page showing 'Choose one of the options below and press continue.'
     Then I choose 'Complex form'
     Then I continue to the next step
     Then I continue to the next step
@@ -154,3 +160,47 @@ Feature: validations
     Then I should see the 'Enter the email address you used to save the form in the correct format' error
     Then I fill 'savedFormEmail' with 'email@test.com'
     Then I continue to the next step
+
+    @complex_form @save_form
+  Scenario: Full Complex Form Submission With Saving The Form
+    Given I start the 'base' application journey
+    Then I choose 'Complex form'
+    Then I continue to the next step
+    Then I choose 'No'
+    Then I continue to the next step
+    Then I fill 'name' with 'Jane Doe'
+    Then I click the 'Continue' button
+    Then I enter a date of birth for a 30 year old
+    Then I click the 'Continue' button
+    Then I fill 'building' with '10 Downing Street'
+    Then I fill 'townOrCity' with 'London'
+    Then I fill 'postcode' with 'W12 3DE'
+    Then I click the 'Continue' button
+    Then I select 'Salary' 
+    Then I select 'Child Benefit' 
+    Then I click the 'Continue' button
+    Then I select 'England and Wales'
+    Then I click the 'Continue' button
+    Then I fill 'countrySelect' with 'United'
+    Then I select 'United Kingdom'
+    Then I click the 'Continue' button
+    Then I fill 'complaintDetails' text area with 'I would like to make a complaint'
+    Then I click the 'Continue' button
+    Then I select 'appealStages' and '01. First Tier IAC Appeal - In Country Appeals'
+    Then I click the 'Continue' button
+    Then I select 'Yes'
+    Then I click the 'Continue' button
+    Then I should see the 'Enter your email address' error
+    Then I should see the 'Create a memorable reference' error
+    Then I fill 'saveEmail' with '=testemail.com'
+    Then I click the 'Continue' button
+    Then I should see the 'Enter your email address in the correct format' error
+    Then I should see the 'Create a memorable reference' error
+    Then I fill 'saveEmail' with 'test@email.com'
+    Then I click the 'Continue' button
+    Then I should see the 'Create a memorable reference' error
+    Then I fill 'saveRef' with 'My saved form'
+    Then I click the 'Continue' button
+    Then I should be on the 'save-confirmation' page showing 'Page not found'
+    Then I click the 'Start again' button
+    Then I should be on the 'landing-page' page showing 'Choose one of the options below and press continue.'


### PR DESCRIPTION
What
Add a save form step for the complex form after '/select' if the user selects 'yes' an email field and a reference field appear, if the user selects 'no' the user is taken to the '/confirm' page as normal.

Why
To give users the option of saving their form