### PR TITLE
Fix request error: change country-select to country

### DIFF
--- a/apps/demo/index.js
+++ b/apps/demo/index.js
@@ -43,7 +43,7 @@ module.exports = {
     '/radio':{
       fields: ['countryOfHearing'],
       forks: [{
-        target: '/country-select',
+        target: '/country',
         condition: {
           field: 'landing-page-radio',
           value: 'complex-form'
@@ -59,7 +59,7 @@ module.exports = {
       fields: ['phone'],
       next: '/confirm'
     },
-    '/country-select': {
+    '/country': {
       behaviours: CountrySelect,
       fields: ['countrySelect'],
       next: '/text-input-area'

--- a/apps/demo/translations/src/en/pages.json
+++ b/apps/demo/translations/src/en/pages.json
@@ -23,7 +23,7 @@
   "radio": {
     "header": "What country was the appeal lodged?"
   },
-  "country-select": {
+  "country": {
     "header": "What country is your address located?"
   },
   "email": {

--- a/test/_features/example_app/complex_form.feature
+++ b/test/_features/example_app/complex_form.feature
@@ -25,7 +25,7 @@ Feature: Complex Form
     Then I should be on the 'radio' page showing 'What country was the appeal lodged?'
     Then I select 'England and Wales'
     Then I click the 'Continue' button
-    Then I should be on the 'country-select' page showing 'What country is your address located?'
+    Then I should be on the 'country' page showing 'What country is your address located?'
     Then I fill 'countrySelect' with 'United'
     Then I select 'United Kingdom'
     Then I click the 'Continue' button


### PR DESCRIPTION
What?

Renamed /country-select to /country.

Why?

As the term 'select' in the uri might be causing the request to be blocked. 

