### PR TITLE
Fix typo on confirmation page

### DIFF
--- a/apps/demo/translations/src/en/pages.json
+++ b/apps/demo/translations/src/en/pages.json
@@ -70,6 +70,6 @@
     "title": "Application complete",
     "alert": "Application complete", 
     "subheader": "Thank you",
-    "content": "You have completed an example of a form built using hof."
+    "content": "You have completed an example of a form built using HOF."
   }
 }


### PR DESCRIPTION
What? 

Fixed typo on the confirmation page - hof -> HOF