### PR TITLE
Fix text on not-both-options step

### DIFF
--- a/apps/demo/translations/src/en/fields.json
+++ b/apps/demo/translations/src/en/fields.json
@@ -92,7 +92,7 @@
     "legend": "Select all that apply",
     "options": {
       "unspecified": {
-        "label": "Unspecified sections and quantities"
+        "label": "Unspecified sections"
       },
       "fully_automatic": {
         "label": "Fully automatic or burst-fire weapons - Section 5(1)(a)"

--- a/apps/demo/translations/src/en/pages.json
+++ b/apps/demo/translations/src/en/pages.json
@@ -38,7 +38,7 @@
   },
   "checkbox-not-both-options":{
     "header": "Which sections do the weapons or components fall under?",
-    "intro": "Select all that apply and state the maximum quantities held at any one time. If the sections and quantities aren't backed up by the evidence provided, it may delay the application or result in the authority not being approved.",
+    "intro": "Select all that apply",
     "important": "Only in certain circumstances, such as transporting prohibited items under seal, should you select the unspecified option."
   },
   "select":{


### PR DESCRIPTION
What? 

Altered the test on the not-both-options step in the complex form. 

Why?

So it makes a bit more sense in the context of the question (which has been modified from firearms - and does not ask they user to input any quantities).