### PR TITLE
Create a new save-and-return route

### DIFF
--- a/apps/demo/index.js
+++ b/apps/demo/index.js
@@ -1,9 +1,9 @@
 /* eslint-disable */
 'use strict';
 
-const CountrySelect = require('./behaviours/country-select')
+const CountrySelect = require('./behaviours/country-select');
 const SummaryPageBehaviour = require('hof').components.summary;
-const getFormSession = require('./behaviours/get-form-session')
+const getFormSession = require('./behaviours/get-form-session');
 const InternationalPhoneNumber = require('./behaviours/international-number');
 const SaveFormSession = require('./behaviours/save-form-session');
 
@@ -24,7 +24,7 @@ module.exports = {
           }
         },
         {
-          target: '/continue-saved-form',
+          target: '/name',
           condition: {
             field: 'landing-page-radio',
             value: 'complex-form'
@@ -43,7 +43,7 @@ module.exports = {
       ],
       next: '/forms',
       forks: [{
-        target: '/name',
+        target: '/text-input-area',
         condition: {
           field: 'continueSavedForms',
           value: 'no'
@@ -106,7 +106,7 @@ module.exports = {
     },
     '/select':{
       fields: ['appealStages'],
-      next: '/save-form'
+      next: '/confirm'
     },
     '/save-form': {
       behaviours: SaveFormSession,

--- a/apps/feature/behaviours/get-form-session.js
+++ b/apps/feature/behaviours/get-form-session.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const axios = require('axios');
+const moment = require('moment');
+const baseUrl = 'http://localhost:3000/forms/';
+const _ = require('lodash');
+
+const encodeEmail = email => Buffer.from(email).toString('hex');
+
+module.exports = superclass => class extends superclass {
+  locals(req, res) {
+    const superlocals = super.locals(req, res);
+    const data = Object.assign({}, {
+      previousForms: _.sortBy(req.formResults, 'id').reverse()
+    });
+    const locals = Object.assign({}, superlocals, data);
+    return locals;
+  }
+
+  getValues(req, res, next) {
+    super.getValues(req, res, err => {
+      if (err) {
+        next(err);
+      }
+      axios.get(baseUrl + encodeEmail(req.sessionModel.get('saveEmail')))
+        .then(function (response) {
+          const resBody = response.data;
+          if (resBody && resBody.length && resBody[0].session) {
+            req.formResults = [];
+            resBody.forEach(form => {
+              const created = moment(form.created_at);
+              const updated = moment(form.updated_at);
+              const formSession = {
+                id: form.id,
+                reference: JSON.stringify(form.session.reference),
+                createdAt: created.format('DD MMMM YYYY'),
+                updatedAt: updated.format('DD MMMM YYYY')
+              };
+              req.formResults.push(formSession);
+            });
+          }
+        })
+        // redirect to /name if the localhost database is not running
+        .catch(function () {
+          return res.redirect('/name');
+        })
+        .then(function () {
+          next();
+        });
+    });
+  }
+};

--- a/apps/feature/fields.js
+++ b/apps/feature/fields.js
@@ -1,0 +1,38 @@
+/* eslint-disable */
+'use strict';
+
+module.exports = {
+  saveEmail: {
+    validate: ['required', 'email']
+  },
+  reference: {
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 20 }],
+  },
+  name: {
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: 200 }],
+  },
+  incomeTypes: {
+    mixin: 'checkbox-group',
+    labelClassName: 'visuallyhidden',
+    validate: ['required'],
+    options: [
+      'salary',
+      'universal_credit',
+      'child_benefit',
+      'housing_benefit',
+      'other'
+    ]
+  },
+  textArea: {
+    mixin: 'textarea',
+    labelClassName: 'visuallyhidden',
+    'ignore-defaults': true,
+    formatter: ['trim', 'hyphens'],
+    validate: ['required', { type: 'maxlength', arguments: 5000 }],
+    attributes: [{
+      attribute: 'rows',
+      value: 8
+    }]
+  },
+
+}

--- a/apps/feature/index.js
+++ b/apps/feature/index.js
@@ -1,0 +1,53 @@
+/* eslint-disable */
+'use strict';
+
+const SummaryPageBehaviour = require('hof').components.summary;
+const getFormSession = require('./behaviours/get-form-session');
+
+module.exports = {
+  name: 'feature',
+  baseUrl: '/feature',
+  steps: {
+    "/save-and-return": {
+      template: 'save-and-return',
+      next: '/start'
+    },
+    '/start': {
+      fields: ['saveEmail'],
+      next: '/forms'
+    },
+    '/forms': {
+      behaviours: getFormSession,
+      template: 'forms',
+      next: '/reference'
+    },
+    '/reference': {
+      fields: ['reference'],
+      template: 'save-and-continue-field',
+      next: '/name' 
+    },
+    '/name': {
+      fields: ['name'],
+      template: 'save-and-continue-field',
+      next: '/checkboxes'
+    },
+    '/checkboxes': {
+      fields: ['incomeTypes'],
+      template: 'save-and-continue-field',
+      next: '/text-area-input'
+    },
+    '/text-area-input': {
+      fields: ['textArea'],
+      template: 'save-and-continue-field',
+      next: '/confirm'
+    },
+    '/confirm': {
+      behaviours: [SummaryPageBehaviour, 'complete'],
+      sections: require('./sections/summary-data-sections'),
+      next: '/confirmation'
+    },
+    '/confirmation': {
+      backLink: false
+    }
+  }
+}

--- a/apps/feature/sections/summary-data-sections.js
+++ b/apps/feature/sections/summary-data-sections.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = {
+  applicantsDetails: [
+    'name',
+  ],
+  income: [
+    'incomeTypes'
+  ],
+  textArea: [
+    'textArea'
+  ],
+};

--- a/apps/feature/sections/summary-data-sections.js
+++ b/apps/feature/sections/summary-data-sections.js
@@ -2,12 +2,12 @@
 
 module.exports = {
   applicantsDetails: [
-    'name',
+    'name'
   ],
   income: [
     'incomeTypes'
   ],
   textArea: [
     'textArea'
-  ],
+  ]
 };

--- a/apps/feature/translations/src/en/buttons.json
+++ b/apps/feature/translations/src/en/buttons.json
@@ -1,0 +1,6 @@
+{
+  "start-form": "Start a form",
+  "create-form": "Create a form",
+  "save-and-exit": "Save and exit",
+  "continue": "Save and continue"
+}

--- a/apps/feature/translations/src/en/fields.json
+++ b/apps/feature/translations/src/en/fields.json
@@ -1,0 +1,37 @@
+{
+  "saveEmail":{
+    "label": "Email address"
+  },
+  "reference": {
+    "label": "What is your reference for this form?",
+    "hint": "This is for you to keep track of your saved forms"
+  },
+  "name": {
+    "label": "Name"
+  },
+  "incomeTypes" : {
+    "label": "Sources of income",
+    "legend": "Select the options where you receive income from",
+    "hint": "Select all options that apply to you.",
+    "options": {
+      "salary": {
+        "label": "Salary"
+      },
+      "universal_credit": {
+        "label": "Universal Credit"
+      },
+      "child_benefit": {
+        "label": "Child Benefit"
+      },
+      "housing_benefit": {
+        "label": "Housing Benefit"
+      },
+      "other": {
+        "label": "Other"
+      }
+    }
+  },
+  "textArea": {
+    "label": "Complaint details"
+  }
+}

--- a/apps/feature/translations/src/en/journey.json
+++ b/apps/feature/translations/src/en/journey.json
@@ -1,0 +1,3 @@
+{
+  "header": "Home Office Forms (HOF) Features"
+}

--- a/apps/feature/translations/src/en/pages.json
+++ b/apps/feature/translations/src/en/pages.json
@@ -1,0 +1,44 @@
+{
+  "save-and-return": {
+    "title": "Save and return feature",
+    "header": "Save and return feature",
+    "subheader": "Try an example of the save and return feature using a HOF form",
+    "text": "In this demo you can use try out a simplified version of the save and return feature which has been implemented by a service, Modern Slavery, which uses the hof framework."
+  },
+  "start": {
+    "header": "Enter your email address",
+    "intro": "Enter your email address to view your previous forms or to start a new form"
+  },
+  "forms": {
+    "title": "Forms"
+  },
+  "reference": {
+    "header": "Give your form a reference"
+  },
+  "name": {
+    "header": "What is your name?"
+  },
+  "checkboxes": {
+    "header": "Where does your money come from each month?"
+  },
+  "text-area-input": {
+    "header": "What are the details of your complaint?",
+    "intro": "Briefly summarise your complaint. Include anything that can help our investigation."
+  },
+  "confirm": {
+    "header": "Check your answers before submitting your application.",
+    "sections": {
+      "applicantsDetails": {
+        "header": "Applicant's details"
+      },
+      "income": {
+        "header": "Income"
+      },
+      "textArea": {
+        "header": "Complaint details"
+      }
+    }
+  },
+  "confirmation": {
+  }
+}

--- a/apps/feature/translations/src/en/pages.json
+++ b/apps/feature/translations/src/en/pages.json
@@ -3,7 +3,7 @@
     "title": "Save and return feature",
     "header": "Save and return feature",
     "subheader": "Try an example of the save and return feature using a HOF form",
-    "text": "In this demo you can use try out a simplified version of the save and return feature which has been implemented by a service, Modern Slavery, which uses the hof framework."
+    "text": "In this demo you can try out a simplified version of the save and return feature which has been implemented by a service, Modern Slavery, which uses the hof framework."
   },
   "start": {
     "header": "Enter your email address",

--- a/apps/feature/translations/src/en/validation.json
+++ b/apps/feature/translations/src/en/validation.json
@@ -1,0 +1,18 @@
+{
+  "saveEmail": {
+    "default": "Enter your email address in the correct format"
+  },
+  "reference": {
+    "required": "You must enter a reference"
+  },
+  "name":{
+    "default": "Enter your full name"
+  },
+  "incomeTypes": {
+    "default": "Select all options that apply to you."
+  },
+  "textArea": {
+    "default": "Enter details about why you are making a complaint",
+    "maxlength": "Keep to the 5000 character limit"
+  }
+}

--- a/apps/feature/views/forms.html
+++ b/apps/feature/views/forms.html
@@ -1,0 +1,45 @@
+<title>{{#t}}pages.forms.title{{/t}} – GOV.UK</title>
+
+{{<partials-page}}
+{{$back}}{{/back}}
+{{$page-content}}
+  {{#fields}}
+    {{#renderField}}{{/renderField}}
+  {{/fields}}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Your reference</th>
+            <th scope="col" class="govuk-table__header">Created on</th>
+            <th scope="col" class="govuk-table__header">Updated on</th>
+            <th scope="col" class="govuk-table__header">Next steps</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          {{#previousForms}}
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">{{reference}}</td>
+              <td class="govuk-table__cell">{{createdAt}}</td>
+              <td class="govuk-table__cell">{{updatedAt}}</td>
+              <td class="govuk-table__cell">
+                <a href="" name="resume" class="govuk-button" >Go to form</a>&nbsp;
+                <a href="" name="delete" class="govuk-button govuk-button--secondary">Delete form</a>
+              </td>
+            </tr>
+          {{/previousForms}}
+          {{^previousForms}}
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell" colspan="5">You do not currently have any draft forms</td>
+          </tr>
+          {{/previousForms}}
+        </tbody>
+      </table>
+      <h2>Create a new form</h2>
+      <p>Create a form and try out the save and return function with Home Office Forms Demo.</p>
+      {{#input-submit}}create-form{{/input-submit}}
+    </div>
+  </div>
+{{/page-content}}
+{{/partials-page}}

--- a/apps/feature/views/partials/save-and-exit-link.html
+++ b/apps/feature/views/partials/save-and-exit-link.html
@@ -1,0 +1,1 @@
+&nbsp;<button class="button" name="save-and-exit" value="save-and-exit">{{#t}}buttons.save-and-exit{{/t}}</button>

--- a/apps/feature/views/save-and-continue-field.html
+++ b/apps/feature/views/save-and-continue-field.html
@@ -1,0 +1,8 @@
+{{<partials-page}}
+{{$page-content}}
+  {{#fields}}
+    {{#renderField}}{{/renderField}}
+  {{/fields}}
+  {{#input-submit}}continue{{/input-submit}} {{> partials-save-and-exit-link}}
+{{/page-content}}
+{{/partials-page}}

--- a/apps/feature/views/save-and-return.html
+++ b/apps/feature/views/save-and-return.html
@@ -1,0 +1,9 @@
+<title>{{#t}}pages.save-and-return.title{{/t}} – GOV.UK</title>
+
+{{<partials-page}}
+  {{$page-content}}
+  <h2>{{#t}}pages.save-and-return.subheader{{/t}}</h2>
+  <p>{{#t}}pages.save-and-return.text{{/t}}</p>
+  {{#input-submit}}start-form{{/input-submit}}
+  {{/page-content}}
+{{/partials-page}}

--- a/hof.settings.json
+++ b/hof.settings.json
@@ -2,7 +2,8 @@
   "appName": "Home Office Forms Demo",
   "theme": "govUK",
   "routes": [
-    "./apps/demo"
+    "./apps/demo",
+    "./apps/feature"
   ],
   "session": {
     "name": "home-office-forms-demo.hof.sid"


### PR DESCRIPTION
**What?**

Create a new route /feature - to demonstrate specific features in the example app. Create a save and return route, which involves a few steps as part of the form, and asks the user for an email and reference at the beginning of the form. This can be accessed by going to /feature. 

**Why?** 

- Separate out the save and return feature from the complex form. 
- Create a shorter form to test out the save and return feature making it easier to demo and tests while developing. 
- Also recreate a save and return feature more similar to modern slavery as well, with the ability to save and exit and save and continue as part of the form questions. 