### PR TITLE
HOFD-6:Delete form when submitted

### DIFF
--- a/apps/feature/behaviours/delete-form-session.js
+++ b/apps/feature/behaviours/delete-form-session.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const axios = require('axios');
+const baseUrl = 'http://localhost:3000/forms/';
+const encodeEmail = email => Buffer.from(email).toString('hex');
+
+module.exports = superclass => class extends superclass {
+  saveValues(req, res, next) {
+    super.saveValues(req, res, err => {
+      if (err) {
+        next(err);
+      }
+      if (req.sessionModel.get('id') && req.sessionModel.get('saveEmail')) {
+        const id = req.sessionModel.get('id');
+        axios.delete(baseUrl + encodeEmail(req.sessionModel.get('saveEmail')) + '/' + id)
+          .then(function () {
+            next();
+          });
+      }
+    });
+  }
+};

--- a/apps/feature/index.js
+++ b/apps/feature/index.js
@@ -7,6 +7,7 @@ const SaveFormSession = require('./behaviours/save-form-session');
 const AreYouSure = require('./behaviours/are-you-sure');
 const SaveAndExit = require('./behaviours/save-and-exit')
 const SummaryPageBehaviour = require('hof').components.summary;
+const DeleteFormSession = require('./behaviours/delete-form-session');
 
 module.exports = {
   name: 'feature',
@@ -57,7 +58,7 @@ module.exports = {
       next: '/confirm'
     },
     '/confirm': {
-      behaviours: [SummaryPageBehaviour, 'complete'],
+      behaviours: [SummaryPageBehaviour, 'complete', DeleteFormSession],
       sections: require('./sections/summary-data-sections'),
       next: '/confirmation'
     },

--- a/apps/feature/translations/src/en/pages.json
+++ b/apps/feature/translations/src/en/pages.json
@@ -3,7 +3,7 @@
     "title": "Save and return feature",
     "header": "Save and return feature",
     "subheader": "Try an example of the save and return feature using a HOF form",
-    "text": "In this demo you can try out a simplified version of the save and return feature which has been implemented by a service, Modern Slavery, which uses the hof framework."
+    "text": "In this demo you can try out a simplified version of the save and return feature which has been implemented by a service, Modern Slavery, which uses the HOF framework. You will be able to save, update and delete the forms you create and when you submit the form it will be deleted from the database."
   },
   "start": {
     "header": "Enter your email address",
@@ -47,6 +47,10 @@
     }
   },
   "confirmation": {
+    "title": "Confirmation",
+    "alert": "Application complete",
+    "subheader": "Save and return demo complete",
+    "content": "The submitted form has now been deleted from the database"
   },
   "save-and-exit": {
     "title": "Save and exit",

--- a/apps/feature/views/confirmation.html
+++ b/apps/feature/views/confirmation.html
@@ -1,0 +1,15 @@
+<title>{{#t}}pages.confirmation.title{{/t}} – GOV.UK</title>
+
+{{<partials-page}}
+  {{$page-content}}
+    <div class="alert-complete" role="alert">
+      <span class="icon icon-complete" role="presentation"></span>
+      <div class="alert-message">
+        <h1>{{#t}}pages.confirmation.alert{{/t}}</h1>
+      </div>
+    </div>
+    <h2>{{#t}}pages.confirmation.subheader{{/t}}</h2>
+    <p>{{#t}}pages.confirmation.content{{/t}}</p>
+    <a href="/feature" class="button" role="button">{{#t}}buttons.start-again{{/t}}</a>
+  {{/page-content}}
+{{/partials-page}}

--- a/test/_features/example_app/save_and_return.feature
+++ b/test/_features/example_app/save_and_return.feature
@@ -3,7 +3,7 @@ Feature: Save and return
   A user should save their form
 
   @save_and_continue
-  Scenario: Got through and delete submitted form
+  Scenario: Go through and delete submitted form
     Given I start the 'feature' application journey
     Then I should be on the 'save-and-return' page showing 'Save and return feature'
     Then I click the 'Start a form' button

--- a/test/_features/example_app/save_and_return.feature
+++ b/test/_features/example_app/save_and_return.feature
@@ -3,12 +3,12 @@ Feature: Save and return
   A user should save their form
 
   @save_and_continue
-  Scenario: Going through the form
+  Scenario: Got through and delete submitted form
     Given I start the 'feature' application journey
     Then I should be on the 'save-and-return' page showing 'Save and return feature'
     Then I click the 'Start a form' button
     Then I should be on the 'start' page showing 'Enter your email address'
-    Then I fill 'saveEmail' with 'test@email.com'
+    Then I fill 'saveEmail' with 'testsubmission@email.com'
     Then I click the 'Save and continue' button
     Then I should be on the 'forms' page showing 'Create a new form'
     Then I continue to the next step
@@ -27,7 +27,14 @@ Feature: Save and return
     Then I click the 'Save and continue' button
     Then I should be on the 'confirm' page showing 'Check your answers before submitting your application.'
     Then I click the 'Confirm submission' button
-    Then I should be on the 'confirmation' page showing 'Application successful'
+    Then I should be on the 'confirmation' page showing 'Application complete'
+    Then I click the 'Start again' button
+    Then I should be on the 'save-and-return' page showing 'Save and return feature'
+    Then I click the 'Start a form' button
+    Then I should be on the 'start' page showing 'Enter your email address'
+    Then I fill 'saveEmail' with 'testsubmission@email.com'
+    Then I click the 'Save and continue' button
+    Then I should be on the 'forms' page showing 'You do not currently have any draft forms'
 
   @save_and_exit
   Scenario: Save and exit of a form
@@ -48,7 +55,7 @@ Feature: Save and return
     Then I should be on the 'save-and-exit' page showing 'You can return to your form at any time from the save and return page.'
 
   @save_and_delete_form
-  Scenario: Creating and deleting a form
+  Scenario: Create and delete a form
     Given I start the 'feature' application journey
     Then I should be on the 'save-and-return' page showing 'Save and return feature'
     Then I click the 'Start a form' button

--- a/test/_features/example_app/validation_save_and_return.feature
+++ b/test/_features/example_app/validation_save_and_return.feature
@@ -37,6 +37,6 @@ Feature: Database validations
     Then I click the 'Save and continue' button
     Then I should be on the 'confirm' page showing 'Check your answers before submitting your application.'
     Then I click the 'Confirm submission' button
-    Then I should be on the 'confirmation' page showing 'Application successful'
+    Then I should be on the 'confirmation' page showing 'Application complete'
 
     


### PR DESCRIPTION
What? 
Add a behaviour to the confirm page which deletes the saved form from the database when the user clicks on the submit button on the form. Acceptance tests added to cover this. 

Why? 
Make is similar to the save and return feature in NRM, the form gets deleted from the database when the user submits the form.